### PR TITLE
Fixing reporting results of mocha runner back to grunt

### DIFF
--- a/tasks/simple-mocha.js
+++ b/tasks/simple-mocha.js
@@ -21,7 +21,16 @@ module.exports = function(grunt) {
         mocha_instance = new Mocha(options);
 
     paths.map(mocha_instance.addFile.bind(mocha_instance));
-    mocha_instance.run(this.async());
+
+    // we will now run mocha asynchronously and receive number of errors in a callback,
+    // which we'll use to report the result of the async task by calling done() with
+    // the appropriate value to indicate whether an error occurred
+    var done = this.async();
+    mocha_instance.run(function(errCount) {
+      // => done(false) if there were errors, done(true) if no errors
+      var withoutErrors = (0 === errCount);
+      done(withoutErrors);
+    });
 
   });
 };


### PR DESCRIPTION
- need to wait until async mocha runner finishes and sends the error count back, then call done() with the appropriate true/false argument
- current implementation sending this.async() directly to mocha runner was wrong as mocha runner was calling it with error count integer instead of true/false boolean
