### PR TITLE
Env support

### DIFF
--- a/tasks/simple-mocha.js
+++ b/tasks/simple-mocha.js
@@ -21,6 +21,12 @@ module.exports = function(grunt) {
         options = this.data.options || {},
         mocha_instance = new Mocha(options);
 
+    if (this.data.env) {
+      for (var opt in this.data.env) {
+        process.env[opt] = this.data.env[opt]
+      }
+    }
+
     paths.map(mocha_instance.addFile.bind(mocha_instance));
 
     // we will now run mocha asynchronously and receive number of errors in a callback,


### PR DESCRIPTION
Allow usage of "env" configuration object that will propagate into process.env object.

We use variety of environment variables in our software and we set them to certain values for tests. I don't want to set them in Gruntfile and this makes an easy & convenient way to achieve that.
