### PR TITLE
Adds mocha of any version (*) as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
     "test": "grunt test"
   },
 
+  "dependencies": {
+    "mocha": "*"
+  },
+
   "devDependencies": {
     "grunt": "~0.3.14"
   },


### PR DESCRIPTION
Maybe there's a great reason to not have [mocha](https://github.com/visionmedia/mocha) actually listed as a dependency, but it took me a moment to realize I was expected to install it myself independently.

`*` as a version requirement will allow any already-existing version of mocha someone might be using in combination with this project, but will install the latest version of they don't have any installed.
