### PR TITLE
Support requiring assertion libs

### DIFF
--- a/tasks/simple-mocha.js
+++ b/tasks/simple-mocha.js
@@ -15,9 +15,18 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('simplemocha', 'Run tests with mocha', function() {
 
     var paths = this.file.src.map(path.resolve),
+        assertionLibs = {
+          should: 'node_modules/should/lib/should',
+          expect: 'node_modules/expect/expect',
+          chai: 'node_modules/chai/chai'
+        },
         options = this.options(),
         mocha_instance = new Mocha(options);
 
+    //optionally include assertion lib
+    if(options.require){
+      mocha_instance.addFile.call(mocha_instance, path.resolve(assertionLibs[options.require]));
+    }
     paths.map(mocha_instance.addFile.bind(mocha_instance));
 
     // We will now run mocha asynchronously and receive number of errors in a


### PR DESCRIPTION
Mocha's CLI allows you to pass a `--require` option for including your assertion library (should, chai, expect etc) so you don't have to require it in every single test.

Mocha's programmatic interface currently doesn't do anything with the "require" option. This pull request shims in support for loading your assertion lib by setting the `require` option. In the future if/when Mocha supports this option, we can drop these few lines and stay completely backwards compatible.

Closes #11
