### PR TITLE
grunt-simple-mocha doesn't work with grunt 0.4.0rc5 due to a change in files

### DIFF
--- a/tasks/simple-mocha.js
+++ b/tasks/simple-mocha.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('simplemocha', 'Run tests with mocha', function() {
 
-    var paths = this.file.src.map(path.resolve),
+    var paths = this.filesSrc.map(path.resolve),
         options = this.options(),
         mocha_instance = new Mocha(options);
 


### PR DESCRIPTION
This patch just changes files.src to filesSrc (see  gruntjs/grunt#606)
