### PR TITLE
Add the 'require' option support

### DIFF
--- a/tasks/simple-mocha.js
+++ b/tasks/simple-mocha.js
@@ -10,13 +10,36 @@
 module.exports = function(grunt) {
 
   var path = require('path'),
-      Mocha = require('mocha');
+      fs = require('fs'),
+      Mocha = require('mocha'),
+      cwd = process.cwd(),
+      join = path.join, 
+      exists = fs.existsSync || path.existsSync;
+
+
+  module.paths.push(cwd, join(cwd, 'node_modules'));
 
   grunt.registerMultiTask('simplemocha', 'Run tests with mocha', function() {
 
     var paths = this.filesSrc.map(path.resolve),
         options = this.options(),
+        required = options.require,
         mocha_instance = new Mocha(options);
+
+    // handle require option
+    if(required) {
+      if(!Array.isArray(required)) {
+        required = [required];
+      }
+      required.forEach(function(mod){
+        var abs = exists(mod)
+          || exists(mod + '.js')
+          || exists(mod + '.coffee');
+
+        if (abs) mod = join(cwd, mod);
+        require(mod);
+      });
+    }
 
     paths.map(mocha_instance.addFile.bind(mocha_instance));
 


### PR DESCRIPTION
The require option of mocha is handled at command line level, so it doesn't work when passing it to the mocha object, to make it work I copied and adapted the code from /bin/_mocha and run the requires before launching the tests.
