### PR TITLE
Fix #22

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
 
   "dependencies": {
-    "mocha": "*"
+    "mocha": "1.7"
   },
 
   "devDependencies": {

--- a/tasks/simple-mocha.js
+++ b/tasks/simple-mocha.js
@@ -14,11 +14,10 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('simplemocha', 'Run tests with mocha', function() {
 
-    var paths = this.filesSrc.map(path.resolve),
-        options = this.options(),
+    var options = this.options(),
         mocha_instance = new Mocha(options);
 
-    paths.map(mocha_instance.addFile.bind(mocha_instance));
+    this.filesSrc.map(mocha_instance.addFile.bind(mocha_instance));
 
     // We will now run mocha asynchronously and receive number of errors in a
     // callback, which we'll use to report the result of the async task by


### PR DESCRIPTION
Fix bug with Grunt 0.4 and revert Mocha to 1.7.x series (1.8 seems bugged on node.js environnement ATM - it can't accept options object without breaking)

I didn't have much time to checkout the issue with Mocha 1.8, but at least this is a fix for the grunt task at the moment.
