### PR TITLE
fixed issue for node.js 0.10.x

### DIFF
--- a/tasks/simple-mocha.js
+++ b/tasks/simple-mocha.js
@@ -14,7 +14,9 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('simplemocha', 'Run tests with mocha', function() {
 
-    var paths = this.filesSrc.map(path.resolve),
+    var paths = this.filesSrc.map(function (fileSrc) {
+          return path.resolve(fileSrc);
+        }),
         options = this.options(),
         mocha_instance = new Mocha(options);
 


### PR DESCRIPTION
Warning: Arguments to path.resolve must be strings Use --force to continue.

Aborted due to warnings.
