### PR TITLE
Fix/simplify path.resolve issue on 0.10 & 0.8

### DIFF
--- a/tasks/simple-mocha.js
+++ b/tasks/simple-mocha.js
@@ -14,11 +14,10 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('simplemocha', 'Run tests with mocha', function() {
 
-    var paths = this.filesSrc.map(path.resolve),
-        options = this.options(),
+    var options = this.options(),
         mocha_instance = new Mocha(options);
 
-    paths.map(mocha_instance.addFile.bind(mocha_instance));
+    this.filesSrc.forEach(mocha_instance.addFile.bind(mocha_instance));
 
     // We will now run mocha asynchronously and receive number of errors in a
     // callback, which we'll use to report the result of the async task by


### PR DESCRIPTION
Mocha already calls path.resolve (https://github.com/visionmedia/mocha/blob/master/lib/mocha.js#L150). The attached is tested on 0.8.22 and 0.10.0.
