### PR TITLE
Fixes #18

### DIFF
--- a/tasks/simple-mocha.js
+++ b/tasks/simple-mocha.js
@@ -17,6 +17,12 @@ module.exports = function(grunt) {
     var options = this.options(),
         mocha_instance = new Mocha(options);
 
+    // Require test modules to be fresh on each run.
+    mocha_instance.suite.on('pre-require', function(context, file) {
+      if(require.cache[file]) {// Module was cached, remove.
+        delete require.cache[file];
+      }
+    });
     this.filesSrc.forEach(mocha_instance.addFile.bind(mocha_instance));
 
     // We will now run mocha asynchronously and receive number of errors in a


### PR DESCRIPTION
By default, a call to require(module) will cache module. This however causes simple-mocha tests to be executed only once when run multiple times (e.g. as part of a regarde/watch task). This fix will delete the test modules from the require() cache prior to each run.

Also see #18.
