### PR TITLE
Add force option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ grunt.registerTask('default', 'simplemocha');
 
 Now, you can just run `grunt simplemocha` in your shell to run the tests. That's it!
 
+## Options
+The ```force``` option specifies that the task should report success, even if tests fail.
+This is useful if you are using watch to continuously run your tests.
+
+The other options are passed to mocha directly.
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding
 style. Add unit tests for any new or changed functionality. Lint and test your

--- a/tasks/simple-mocha.js
+++ b/tasks/simple-mocha.js
@@ -15,7 +15,10 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('simplemocha', 'Run tests with mocha', function() {
 
     var options = this.options(),
-        mocha_instance = new Mocha(options);
+        mocha_instance = new Mocha(options),
+        force = options.force;
+
+    options.force = undefined;
 
     this.filesSrc.forEach(mocha_instance.addFile.bind(mocha_instance));
 
@@ -27,7 +30,7 @@ module.exports = function(grunt) {
     var done = this.async();
 
     mocha_instance.run(function(errCount) {
-      var withoutErrors = (errCount === 0);
+      var withoutErrors = force || (errCount === 0);
       done(withoutErrors);
     });
   });


### PR DESCRIPTION
Add a force option so that execution can continue when a test fails.

I use this when using grunt-contrib-watch to continuously run tests, where I don't want to use --force globally for all tasks.

This will be obviated if per-task force is added to grunt: https://github.com/gruntjs/grunt/issues/810
