### PR TITLE
Allow mocha to handle uncaught exceptions instead of grunt

### DIFF
--- a/tasks/simple-mocha.js
+++ b/tasks/simple-mocha.js
@@ -26,7 +26,21 @@ module.exports = function(grunt) {
 
     var done = this.async();
 
+    // Grunt registers a handler for uncaught exceptions that
+    // immediately fails the current task. However mocha also has its
+    // own handler for uncaught exceptions that fails the current test
+    // case which gets pre-empted by the grunt handlers.
+    //
+    // To handle this, temporarily remove any handlers and then
+    // restore them when mocha is all done.
+    var handlers = process.listeners('uncaughtException');
+    process.removeAllListeners('uncaughtException');
+
     mocha_instance.run(function(errCount) {
+      handlers.forEach(function(h) {
+          process.on('uncaughtException', h);
+      });
+
       var withoutErrors = (errCount === 0);
       done(withoutErrors);
     });


### PR DESCRIPTION
Mocha has its own uncaught exception handler which gets pre-empted by
the one that grunt installs. Temporarily remove the grunt one while mocha
is running to let it handle the exceptions.
