### PR TITLE
add a grunt.warn message if any tests fail

### DIFF
--- a/tasks/simple-mocha.js
+++ b/tasks/simple-mocha.js
@@ -27,6 +27,9 @@ module.exports = function(grunt) {
     var done = this.async();
 
     mocha_instance.run(function(errCount) {
+      if (errCount !== 0) {
+          grunt.warn(errCount + "/" + mocha_instance.suite.total() + " tests failed.");
+      }
       var withoutErrors = (errCount === 0);
       done(withoutErrors);
     });


### PR DESCRIPTION
Currently if any of the mocha tests called from within grunt simplemocha fail, it emits an error like:

```
Warning: Task "simplemocha:server" failed. Use --force to continue.
Error: Task "simplemocha:server" failed.
    at Task.<anonymous (.../grunt/lib/util/task.js:197:15)
    at null._onTimeout (.../grunt/lib/util/task.js:225:33)
    at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
Aborted due to warnings.
```

By adding the call to grunt.warn this turns into the much nicer:

```
Warning: 1/6 tests failed. Use --force to continue.
Aborted due to warnings.
```
