### PR TITLE
Advanced Config Example Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ grunt.initConfig({
       bail: false,
       slow: 2000,
       ignoreLeaks: false,
-      fullTrace: true
-      grep: 'users',
+      fullTrace: true,
+      grep: 'users'
     },
 
     all: { src: ['test/**/*.js'] }


### PR DESCRIPTION
This pull request changes the Advanced Config example to use trailing commas correctly so that users will have less difficulty if copying and pasting config settings.
