### PR TITLE
Fail if test files throw on load

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "grunt": "0.4.x",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-jshint": "0.1.x",
     "mocha": "^2.3.4"
   },

--- a/tasks/simple-mocha.js
+++ b/tasks/simple-mocha.js
@@ -26,9 +26,20 @@ module.exports = function(grunt) {
 
     var done = this.async();
 
-    mocha_instance.run(function(errCount) {
-      var withoutErrors = (errCount === 0);
-      done(withoutErrors);
-    });
+    // Exceptions thrown from here will not trigger a Grunt task failure.
+    // We must manually fail the task.
+    //
+    // Calling run() on mocha_instance will cause all files provided to
+    // mocha_instance.addFile to load and run. Exceptions encountered while
+    // loading these files will show up here (for instance, mistyping a require
+    // in a spec file).
+    try {
+      mocha_instance.run(function(errCount) {
+        var withoutErrors = (errCount === 0);
+        done(withoutErrors);
+      });
+    } catch (e) {
+      grunt.fail.fatal(e);
+    }
   });
 };

--- a/tests/acceptance-tests.js
+++ b/tests/acceptance-tests.js
@@ -34,4 +34,12 @@ describe('acceptance tests for simplemocha', function() {
       done();
     });
   });
+
+  it('fails if files loaded into mocha do not load cleanly', function(done) {
+    grunt('error-on-load', function(error, stdout, stderr) {
+      assert(error, 'expected error to be thrown on load');
+      assert.ok(error.code > 0);
+      done();
+    });
+  });
 });

--- a/tests/fixtures/error-on-load.gruntfile.js
+++ b/tests/fixtures/error-on-load.gruntfile.js
@@ -1,0 +1,11 @@
+module.exports = function(grunt) {
+  grunt.loadTasks('../../tasks');
+
+  grunt.initConfig({
+    simplemocha: {
+      all: { src: ['./error-on-load.js'] }
+    }
+  });
+
+  grunt.registerTask('default', 'simplemocha');
+};

--- a/tests/fixtures/error-on-load.js
+++ b/tests/fixtures/error-on-load.js
@@ -1,0 +1,1 @@
+throw new Error('Error thrown on loading file');


### PR DESCRIPTION
If the files loaded into mocha throw an error on load (i.e, someone mistyped a `require`), the current behavior is to silently catch the error and report success. I think this is actually a Grunt behavior (async tasks don't fail if they throw), but I don't think we'll have any luck changing how Grunt works.

I also added a missing dev dependency to `package.json` to get the tests working again.
